### PR TITLE
Feat/36 openvpn

### DIFF
--- a/Terraform_Project/environments/dev/main.tf
+++ b/Terraform_Project/environments/dev/main.tf
@@ -19,6 +19,17 @@ module "network" {
   ]
 }
 
+module "security_groups" {
+  source = "../../modules/security_groups"
+  vpc_id = module.network.vpc_id
+}
+
+module "openvpn" {
+  source = "../../modules/openvpn"
+  subnet_id               = module.network.public_subnet_ids[0]
+  vpc_security_group_ids  = [module.security_groups.sg_openvpn.id]
+}
+
 # module "asg" {
 #   source = "../modules/asg"
 

--- a/Terraform_Project/modules/openvpn/main.tf
+++ b/Terraform_Project/modules/openvpn/main.tf
@@ -1,0 +1,16 @@
+# openvpn 인스턴스 생성
+resource "aws_instance" "openvpn" {
+    ami                         = var.ami
+    instance_type               = var.instance_type
+    subnet_id                   = var.subnet_id
+    vpc_security_group_ids      = var.vpc_security_group_ids
+    associate_public_ip_address = var.associate_public_ip_address
+    source_dest_check           = false
+    key_name                    = var.key_name
+
+    user_data = file("${path.module}/openvpn-setup.sh")
+
+    tags = {
+      Name = "koco_openvpn"
+    }
+}

--- a/Terraform_Project/modules/openvpn/openvpn-setup.sh
+++ b/Terraform_Project/modules/openvpn/openvpn-setup.sh
@@ -8,7 +8,7 @@ sleep 90  # Increased wait time to ensure full initialization
 
 # Set admin password
 echo "Setting admin password..."
-ADMIN_PASSWORD="koco" # Change this to your desired password
+ADMIN_PASSWORD="-" # Change this to your desired password
 # Use the correct method to set the OpenVPN admin password
 sudo /usr/local/openvpn_as/scripts/sacli --user openvpn --new_pass "$ADMIN_PASSWORD" SetLocalPassword
 
@@ -48,13 +48,13 @@ sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.client.routing.reroute_gw" -
 echo "Creating client profile..."
 sudo /usr/local/openvpn_as/scripts/sacli --user client1 --key "prop_autologin" --value "true" UserPropPut
 sudo /usr/local/openvpn_as/scripts/sacli --user client1 --key "prop_superuser" --value "false" UserPropPut
-sudo /usr/local/openvpn_as/scripts/sacli --user client1 --new_pass "ClientPassword123" SetLocalPassword
+sudo /usr/local/openvpn_as/scripts/sacli --user client1 --new_pass "-" SetLocalPassword
 
 # Create an admin user profile
 echo "Creating admin profile..."
 sudo /usr/local/openvpn_as/scripts/sacli --user admin --key "prop_autologin" --value "true" UserPropPut
 sudo /usr/local/openvpn_as/scripts/sacli --user admin --key "prop_superuser" --value "true" UserPropPut
-sudo /usr/local/openvpn_as/scripts/sacli --user admin --new_pass "AdminPassword123" SetLocalPassword
+sudo /usr/local/openvpn_as/scripts/sacli --user admin --new_pass "-" SetLocalPassword
 
 # Apply changes and restart services
 echo "Applying changes and restarting services..."

--- a/Terraform_Project/modules/openvpn/openvpn-setup.sh
+++ b/Terraform_Project/modules/openvpn/openvpn-setup.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# This script configures an existing OpenVPN Access Server installation
+# to allow access to an EKS cluster in a separate VPC
+
+# Wait for the OpenVPN Access Server to fully initialize
+echo "Waiting for OpenVPN Access Server to initialize..."
+sleep 90  # Increased wait time to ensure full initialization
+
+# Set admin password
+echo "Setting admin password..."
+ADMIN_PASSWORD="koco" # Change this to your desired password
+# Use the correct method to set the OpenVPN admin password
+sudo /usr/local/openvpn_as/scripts/sacli --user openvpn --new_pass "$ADMIN_PASSWORD" SetLocalPassword
+
+# Enable IP forwarding
+echo "Enabling IP forwarding..."
+sudo sysctl -w net.ipv4.ip_forward=1
+echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+
+# Configure OpenVPN server settings using sacli
+echo "Configuring OpenVPN server settings..."
+# Set server hostname to public IP
+sudo /usr/local/openvpn_as/scripts/sacli --key "host.name" --value "$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)" ConfigPut
+
+# Configure standard ports
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.daemon.tcp.port" --value "443" ConfigPut
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.daemon.udp.port" --value "1194" ConfigPut
+
+# Configure both VPC CIDR blocks for routing
+# Prod VPC (OpenVPN 서버 위치)
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_network.0" --value "10.1.0.0/16" ConfigPut
+
+# Enable client-to-client routing (allows VPN clients to communicate with each other)
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_access" --value "true" ConfigPut
+
+# Push DNS server (VPC의 기본 DNS는 .2)
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.dhcp_option.dns.0" --value "10.1.0.2" ConfigPut
+
+# Enable NAT for all VPC CIDR blocks
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.nat.enable" --value "true" ConfigPut
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.nat.netmask.0" --value "10.1.0.0/16" ConfigPut
+
+# Use split tunneling (only route VPC traffic through VPN)
+sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.client.routing.reroute_gw" --value "true" ConfigPut
+
+# Create a client profile
+echo "Creating client profile..."
+sudo /usr/local/openvpn_as/scripts/sacli --user client1 --key "prop_autologin" --value "true" UserPropPut
+sudo /usr/local/openvpn_as/scripts/sacli --user client1 --key "prop_superuser" --value "false" UserPropPut
+sudo /usr/local/openvpn_as/scripts/sacli --user client1 --new_pass "ClientPassword123" SetLocalPassword
+
+# Create an admin user profile
+echo "Creating admin profile..."
+sudo /usr/local/openvpn_as/scripts/sacli --user admin --key "prop_autologin" --value "true" UserPropPut
+sudo /usr/local/openvpn_as/scripts/sacli --user admin --key "prop_superuser" --value "true" UserPropPut
+sudo /usr/local/openvpn_as/scripts/sacli --user admin --new_pass "AdminPassword123" SetLocalPassword
+
+# Apply changes and restart services
+echo "Applying changes and restarting services..."
+sudo /usr/local/openvpn_as/scripts/sacli start
+
+# Generate client configuration profiles
+echo "Generating client profiles for download..."
+mkdir -p /tmp/client_profiles
+
+# Generate client1 profile
+CLIENT1_PROFILE=$(sudo /usr/local/openvpn_as/scripts/sacli --user client1 GetAutologin)
+echo "$CLIENT1_PROFILE" > /tmp/client_profiles/client1.ovpn
+
+# Generate admin profile
+ADMIN_PROFILE=$(sudo /usr/local/openvpn_as/scripts/sacli --user admin GetAutologin)
+echo "$ADMIN_PROFILE" > /tmp/client_profiles/admin.ovpn
+
+# Set readable permissions
+chmod 644 /tmp/client_profiles/*.ovpn
+
+# Display information about how to connect
+PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+echo "OpenVPN Access Server has been configured!"
+echo "Admin web interface: https://$PUBLIC_IP:943/admin"
+echo "Admin username: openvpn"
+echo "Admin password: $ADMIN_PASSWORD"
+echo ""
+echo "Client profiles have been generated in /tmp/client_profiles/"
+echo "Use 'scp' to download them to your local machine:"
+echo "scp -i your-key.pem ec2-user@$PUBLIC_IP:/tmp/client_profiles/*.ovpn ."
+echo ""
+echo "Alternative URLs for client profiles:"
+echo "https://$PUBLIC_IP:943/?src=connect client1"
+echo "https://$PUBLIC_IP:943/?src=connect admin"
+echo ""
+echo "IMPORTANT: Make sure your AWS VPC routing is properly configured:"
+echo "- Verify there's a route between the 10.110.0.0/16 VPC and 10.120.0.0/16 VPC"
+echo "- Check that security groups allow traffic between VPCs and from VPN clients"

--- a/Terraform_Project/modules/openvpn/variables.tf
+++ b/Terraform_Project/modules/openvpn/variables.tf
@@ -1,0 +1,33 @@
+variable "ami" {
+  description = "OpenVPN Access Server 인스턴스에 사용할 AMI ID"
+  type        = string
+  default     = "ami-09a093fa2e3bfca5a" 
+}
+
+variable "instance_type" {
+  description = "EC2 인스턴스 타입"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "subnet_id" {
+  description = "OpenVPN 인스턴스를 배포할 서브넷 ID"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "인스턴스에 적용할 보안 그룹 ID 목록"
+  type        = list(string)
+}
+
+variable "associate_public_ip_address" {
+  description = "퍼블릭 IP 자동 할당 여부"
+  type        = bool
+  default     = true
+}
+
+variable "key_name" {
+  description = "key pair 이름"
+  type = string
+  default = "KoCo_testServer_key"  
+}

--- a/Terraform_Project/modules/security_groups/main.tf
+++ b/Terraform_Project/modules/security_groups/main.tf
@@ -1,0 +1,39 @@
+resource "aws_security_group" "sg_openvpn" { # openvpn 보안 그룹
+    name   = "sg_openvpn"
+    vpc_id = var.vpc_id
+
+    ingress { # 인바운드
+        from_port = 22
+        to_port = 22
+        protocol = "tcp"
+        cidr_blocks = [ "0.0.0.0/0" ]
+    }
+
+    ingress { # 인바운드
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"
+        cidr_blocks = [ "0.0.0.0/0" ]
+    }
+
+    ingress {
+      from_port = 1194
+        to_port = 1194
+        protocol = "tcp"
+        cidr_blocks = [ "0.0.0.0/0" ]
+    }
+
+    ingress {
+      from_port = 943
+        to_port = 943
+        protocol = "tcp"
+        cidr_blocks = [ "0.0.0.0/0" ]
+    }
+
+    egress { # 아웃바운드
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/Terraform_Project/modules/security_groups/outputs.tf
+++ b/Terraform_Project/modules/security_groups/outputs.tf
@@ -1,0 +1,3 @@
+output "sg_openvpn" {
+  value = aws_security_group.sg_openvpn
+}

--- a/Terraform_Project/modules/security_groups/variables.tf
+++ b/Terraform_Project/modules/security_groups/variables.tf
@@ -1,0 +1,3 @@
+variable "vpc_id" {
+    type = string
+}


### PR DESCRIPTION
## 📝 개요
- 테라폼으로 OpenVPN 인스턴스 생성 및 환경셋팅

## 🔗 연관된 이슈
- #36 

## 🔄 변경사항 및 이유
- Terraform 모듈을 이용해 OpenVPN 서버 인스턴스를 생성하는 코드 추가
- aws_instance에 필요한 VPC, subnet, security group 등 외부 모듈 연동
- source_dest_check = false 설정을 통해 VPN 라우팅 트래픽 허용
- 초기 설정을 위한 openvpn-setup.sh 스크립트 추가 및 구성
- 보안 강화를 위해 setup 스크립트 내 비밀번호 하드코딩 제거

## 📋 작업할 내용
- [x] OpenVPN 서버용 EC2 인스턴스 생성 코드 작성
- [x] user_data를 통해 OpenVPN 자동 설치 및 초기 설정 스크립트 작성
- [x] 외부에서 접근 가능한 보안 그룹 설정
- [x] Elastic IP 할당 및 연결

## 🔖 기타사항
- [ ] 추가 논의가 필요한 이슈 있음
- [ ] 외부 라이브러리 사용 예정
- [ ] 성능 고려 필요
- [ ] 보안 고려 필요

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
