### PR TITLE
Feat: ALB + Target Group + Listener 구성

### DIFF
--- a/Terraform_Project/environments/dev/main.tf
+++ b/Terraform_Project/environments/dev/main.tf
@@ -30,6 +30,14 @@ module "openvpn" {
   vpc_security_group_ids  = [module.security_groups.sg_openvpn.id]
 }
 
+module "alb" {
+  source = "../../modules/alb"
+  security_group_ids = [module.security_groups.sg_alb.id]
+  subnet_ids = module.network.private_app_subnet_ids
+  vpc_id = module.network.vpc_id
+  certificate_arn = var.certificate_arn
+}
+
 # module "asg" {
 #   source = "../modules/asg"
 

--- a/Terraform_Project/environments/dev/variables.tf
+++ b/Terraform_Project/environments/dev/variables.tf
@@ -1,0 +1,5 @@
+variable "certificate_arn" {
+  description = "Certificate ARN for HTTPS"
+  type        = string
+  default     = ""
+}

--- a/Terraform_Project/modules/alb/main.tf
+++ b/Terraform_Project/modules/alb/main.tf
@@ -1,0 +1,89 @@
+# ALB 생성
+resource "aws_lb" "this" {
+  name               = var.alb_name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = var.security_group_ids
+  subnets            = var.subnet_ids
+
+  tags = {
+    Name        = var.alb_name
+  }
+}
+
+# ALB 대상 그룹 생성 (HTTP 포트 80)
+resource "aws_lb_target_group" "blue" {
+  name     = "${var.target_group_name}-blue-tg"
+  port     = var.target_group_port
+  protocol = var.target_group_protocol
+  vpc_id   = var.vpc_id
+
+  health_check {
+    path                = "/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+  tags = {
+    Name   = "${var.target_group_name}-blue-tg"
+  }
+}
+
+resource "aws_lb_target_group" "green" {
+  name     = "${var.target_group_name}-green-tg"
+  port     = var.target_group_port
+  protocol = var.target_group_protocol
+  vpc_id   = var.vpc_id
+
+  health_check {
+    path                = "/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+  tags = {
+    Name   = "${var.target_group_name}-green-tg"
+  }
+}
+
+# ALB Listener 생성
+# 1. HTTP → HTTPS 리디렉션
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      protocol    = "HTTPS"
+      port        = "443"
+      status_code = "HTTP_301"
+    }
+  }
+  tags = {
+    Name = var.listener_http_name
+  }
+}
+
+# 2. HTTPS 리스너 → 대상 그룹으로 요청 전달
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.blue.arn  # 기본은 Blue로
+  }
+
+  tags = {
+    Name = var.listener_https_name
+  }
+}

--- a/Terraform_Project/modules/alb/outputs.tf
+++ b/Terraform_Project/modules/alb/outputs.tf
@@ -1,0 +1,3 @@
+output "dns_name"{
+    value = aws_lb.this.dns_name
+}

--- a/Terraform_Project/modules/alb/variables.tf
+++ b/Terraform_Project/modules/alb/variables.tf
@@ -1,0 +1,85 @@
+variable "alb_name" {
+  description = "ALB 이름"
+  type        = string
+  default     = "koco-app-alb"
+}
+
+variable "subnet_ids" {
+  description = "ALB를 배포할 퍼블릭 서브넷 ID 목록"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "ALB에 적용할 보안 그룹 ID 목록"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "ALB 대상 그룹 생성을 위한 VPC ID"
+  type        = string
+}
+
+variable "target_group_name" {
+  description = "ALB 대상 그룹 이름"
+  type        = string
+  default     = "koco-app"
+}
+
+variable "target_group_port" {
+  description = "대상 그룹 포트"
+  type        = number
+  default     = 80
+}
+
+variable "target_group_protocol" {
+  description = "대상 그룹 프로토콜"
+  type        = string
+  default     = "HTTP"
+}
+
+variable "health_check_path" {
+  description = "헬스 체크 경로"
+  type        = string
+  default     = "/health"
+}
+
+variable "health_check_protocol" {
+  description = "헬스 체크 프로토콜"
+  type        = string
+  default     = "HTTP"
+}
+
+variable "health_check_matcher" {
+  description = "헬스 체크 응답 매처"
+  type        = string
+  default     = "200"
+}
+
+variable "listener_port" {
+  description = "ALB 리스너 포트"
+  type        = number
+  default     = 80
+}
+
+variable "listener_protocol" {
+  description = "ALB 리스너 프로토콜"
+  type        = string
+  default     = "HTTP"
+}
+
+variable "certificate_arn" { # 값 넣어 주어야 함
+  description = "Certificate ARN for HTTPS"
+  type        = string
+}
+
+variable "listener_http_name" {
+  description = "ALB http 리스너 이름"
+  type        = string
+  default     = "koco-app-listener-http"
+}
+
+variable "listener_https_name" {
+  description = "ALB https 리스너 이름"
+  type        = string
+  default     = "koco-app-listener-https"
+}

--- a/Terraform_Project/modules/openvpn/openvpn-setup.sh
+++ b/Terraform_Project/modules/openvpn/openvpn-setup.sh
@@ -8,7 +8,7 @@ sleep 90  # Increased wait time to ensure full initialization
 
 # Set admin password
 echo "Setting admin password..."
-ADMIN_PASSWORD="-" # Change this to your desired password
+ADMIN_PASSWORD="koco" # Change this to your desired password
 # Use the correct method to set the OpenVPN admin password
 sudo /usr/local/openvpn_as/scripts/sacli --user openvpn --new_pass "$ADMIN_PASSWORD" SetLocalPassword
 

--- a/Terraform_Project/modules/security_groups/main.tf
+++ b/Terraform_Project/modules/security_groups/main.tf
@@ -2,14 +2,14 @@ resource "aws_security_group" "sg_openvpn" { # openvpn 보안 그룹
     name   = "sg_openvpn"
     vpc_id = var.vpc_id
 
-    ingress { # 인바운드
+    ingress { 
         from_port = 22
         to_port = 22
         protocol = "tcp"
         cidr_blocks = [ "0.0.0.0/0" ]
     }
 
-    ingress { # 인바운드
+    ingress { 
         from_port = 443
         to_port = 443
         protocol = "tcp"
@@ -19,7 +19,7 @@ resource "aws_security_group" "sg_openvpn" { # openvpn 보안 그룹
     ingress {
       from_port = 1194
         to_port = 1194
-        protocol = "tcp"
+        protocol = "udp"
         cidr_blocks = [ "0.0.0.0/0" ]
     }
 
@@ -30,7 +30,35 @@ resource "aws_security_group" "sg_openvpn" { # openvpn 보안 그룹
         cidr_blocks = [ "0.0.0.0/0" ]
     }
 
-    egress { # 아웃바운드
+    egress { 
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "sg_alb" { # alb 보안 그룹
+  name   = "sg_alb"
+  description = "Allow HTTP and HTTPS inbound traffic to ALB"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"] 
+    description = ""
+  }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = ""
+  }
+
+  egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"

--- a/Terraform_Project/modules/security_groups/outputs.tf
+++ b/Terraform_Project/modules/security_groups/outputs.tf
@@ -1,3 +1,7 @@
 output "sg_openvpn" {
   value = aws_security_group.sg_openvpn
 }
+
+output "sg_alb" {
+  value = aws_security_group.sg_alb
+}


### PR DESCRIPTION
## 📝 개요
- 테라폼으로 alb 생성

## 🔗 연관된 이슈
- #37 

## 🔄 변경사항 및 이유
- aws_lb, aws_lb_target_group, aws_lb_listener 리소스를 새로 추가했습니다.
- Blue/Green 배포 전략을 고려하여 두 개의 Target Group (blue, green)을 생성했습니다.
- ALB Listener는 HTTP(80) → HTTPS(443) 리디렉션을 구성했고, HTTPS Listener는 기본적으로 Blue Target Group으로 포워딩되도록 설정했습니다.
- 이후 CodeDeploy 등과의 연계를 고려하여 확장 가능한 구조로 설계했습니다.

## 📋 작업할 내용
- [x] ALB 리소스 생성 (퍼블릭 ALB)
- [x] Blue/Green Target Group 생성 및 Health Check 설정
- [x]  HTTP → HTTPS 리디렉션 Listener 구성 
- [x] HTTPS Listener에서 Blue Target Group으로 요청 포워딩
- [x]  Terraform 모듈화 및 변수화
- [x]  기본 헬스체크 경로 /health 구성
- [x] Listener/Target Group 이름 태깅

## 🔖 기타사항


## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
