### PR TITLE
Feat: 이미지 저장용, 프론트 배포용 s3 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ Terraform_Project/backend/terraform.tfvars*
 Terraform_Project/environments/dev/.terraform/
 Terraform_Project/environments/dev/.terraform/terraform.tfstate*
 Terraform_Project/environments/dev/terraform.tfvars*
+
+Terraform_Project/environments/s3/.terraform/
+Terraform_Project/environments/s3/.terraform/terraform.tfstate*
+Terraform_Project/environments/s3/terraform.tfvars*

--- a/Terraform_Project/environments/dev/main.tf
+++ b/Terraform_Project/environments/dev/main.tf
@@ -60,5 +60,3 @@ module "alb" {
 #     module.ec2       // ec2 모듈이 완료된 후 실행
 #   ]
 # }
-
-

--- a/Terraform_Project/environments/dev/variables.tf
+++ b/Terraform_Project/environments/dev/variables.tf
@@ -1,5 +1,5 @@
 variable "certificate_arn" {
   description = "Certificate ARN for HTTPS"
   type        = string
-  default     = ""
+  default     = "arn:aws:acm:ap-northeast-2:266735804784:certificate/98e5640b-0c86-4d47-a696-b1159e04093a"
 }

--- a/Terraform_Project/environments/s3/.terraform.lock.hcl
+++ b/Terraform_Project/environments/s3/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.92.0"
+  constraints = "~> 5.92.0"
+  hashes = [
+    "h1:Hm5w8euRSm6tZyc60+nVPQheCikB7P0NhFI/dSFK0IM=",
+    "zh:1d3a0b40831360e8e988aee74a9ff3d69d95cb541c2eae5cb843c64303a091ba",
+    "zh:3d29cbced6c708be2041a708d25c7c0fc22d09e4d0b174360ed113bfae786137",
+    "zh:4341a203cf5820a0ca18bb514ae10a6c113bc6a728fb432acbf817d232e8eff4",
+    "zh:4a49e2d91e4d92b6b93ccbcbdcfa2d67935ce62e33b939656766bb81b3fd9a2c",
+    "zh:54c7189358b37fd895dedbabf84e509c1980a8c404a1ee5b29b06e40497b8655",
+    "zh:5d8bb1ff089c37cb65c83b4647f1981fded993e87d8132915d92d79f29e2fcd8",
+    "zh:618f2eb87cd65b245aefba03991ad714a51ff3b841016ef68e2da2b85d0b2325",
+    "zh:7bce07bc542d0588ca42bac5098dd4f8af715417cd30166b4fb97cedd44ab109",
+    "zh:81419eab2d8810beb114b1ff5cbb592d21edc21b809dc12bb066e4b88fdd184a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9dea39d4748eeeebe2e76ca59bca4ccd161c2687050878c47289a98407a23372",
+    "zh:d692fc33b67ac89e916c8f9233d39eacab8c438fe10172990ee9d94fba5ca372",
+    "zh:d9075c7da48947c029ba47d5985e1e8e3bf92367bfee8ca1ff0e747765e779a1",
+    "zh:e81c62db317f3b640b2e04eba0ada8aa606bcbae0152c09f6242e86b86ef5889",
+    "zh:f68562e073722c378d2f3529eb80ad463f12c44aa5523d558ae3b69f4de5ca1f",
+  ]
+}

--- a/Terraform_Project/environments/s3/main.tf
+++ b/Terraform_Project/environments/s3/main.tf
@@ -1,0 +1,7 @@
+module "koco_s3" {
+  source = "../../modules/koco_s3"
+}
+
+module "front_s3" {
+  source = "../../modules/front_s3"
+}

--- a/Terraform_Project/environments/s3/providers.tf
+++ b/Terraform_Project/environments/s3/providers.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.92.0"
+    }
+  }
+
+  # (옵션) 백엔드 설정: 원격 상태 저장소를 사용하는 경우 설정
+  backend "s3" {
+    bucket = "evan-terraformstate"
+    key  = "./terraform.tfstate"
+    region = "ap-northeast-2"
+    encrypt = true
+    dynamodb_table = "evan-terraformstate"
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/Terraform_Project/modules/front_s3/main.tf
+++ b/Terraform_Project/modules/front_s3/main.tf
@@ -1,0 +1,46 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.bucket_name 
+  force_destroy = false     # 버킷 비우기 없이 삭제 방지
+
+  lifecycle {
+    prevent_destroy = true       # 실수로 삭제되는 것 방지
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = false  # 웹 호스팅을 위해 false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject",
+        Effect    = "Allow",
+        Principal = "*",
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.frontend.arn}/*"
+      }
+    ]
+  })
+}

--- a/Terraform_Project/modules/front_s3/variables.tf
+++ b/Terraform_Project/modules/front_s3/variables.tf
@@ -1,0 +1,5 @@
+variable "bucket_name" {
+  description = "Frontend static hosting bucket name"
+  type        = string
+  default = "koco-front-s3"
+}

--- a/Terraform_Project/modules/koco_s3/main.tf
+++ b/Terraform_Project/modules/koco_s3/main.tf
@@ -1,0 +1,35 @@
+resource "aws_s3_bucket" "image" {
+  bucket = var.bucket_name
+  force_destroy = false     # 버킷 비우기 없이 삭제 방지
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "image" {
+  bucket = aws_s3_bucket.image.id
+
+  block_public_acls       = true
+  block_public_policy     = false  # 버킷 정책은 허용해야 하므로 false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "image" {
+  bucket = aws_s3_bucket.image.id
+  depends_on = [aws_s3_bucket_public_access_block.image]  # 퍼블릭 설정 먼저 적용됨을 보장
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowPublicReadProfileFolder",
+        Effect    = "Allow",
+        Principal = "*",
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.image.arn}/profile/*"
+      }
+    ]
+  })
+}

--- a/Terraform_Project/modules/koco_s3/variables.tf
+++ b/Terraform_Project/modules/koco_s3/variables.tf
@@ -1,0 +1,5 @@
+variable "bucket_name" {
+  description = "이미지 저장용 버킷 이름 (예: koco-s3)"
+  type        = string
+  default = "koco-img-s3"
+}

--- a/Terraform_Project/modules/openvpn/openvpn-setup.sh
+++ b/Terraform_Project/modules/openvpn/openvpn-setup.sh
@@ -48,13 +48,13 @@ sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.client.routing.reroute_gw" -
 echo "Creating client profile..."
 sudo /usr/local/openvpn_as/scripts/sacli --user client1 --key "prop_autologin" --value "true" UserPropPut
 sudo /usr/local/openvpn_as/scripts/sacli --user client1 --key "prop_superuser" --value "false" UserPropPut
-sudo /usr/local/openvpn_as/scripts/sacli --user client1 --new_pass "-" SetLocalPassword
+sudo /usr/local/openvpn_as/scripts/sacli --user client1 --new_pass "ClientPassword123" SetLocalPassword
 
 # Create an admin user profile
 echo "Creating admin profile..."
 sudo /usr/local/openvpn_as/scripts/sacli --user admin --key "prop_autologin" --value "true" UserPropPut
 sudo /usr/local/openvpn_as/scripts/sacli --user admin --key "prop_superuser" --value "true" UserPropPut
-sudo /usr/local/openvpn_as/scripts/sacli --user admin --new_pass "-" SetLocalPassword
+sudo /usr/local/openvpn_as/scripts/sacli --user admin --new_pass "AdminPassword123" SetLocalPassword
 
 # Apply changes and restart services
 echo "Applying changes and restarting services..."


### PR DESCRIPTION
## 📝 개요
- 테라폼으로 프로필 이미지 저장용, 프론트 배포용 s3 생성

## 🔗 연관된 이슈
- #39 

## 🔄 변경사항 및 이유
- Terraform을 통해 S3 버킷 2종을 생성했습니다.
> koco-img-s3: 사용자 프로필 이미지 저장용
> koco-front-s3: React 앱 정적 파일 배포용

- 두 버킷 모두 실수로 삭제되지 않도록 prevent_destroy = true 옵션을 설정했습니다.
- koco-img-s3는 지정된 경로(/profile/*)만 퍼블릭 읽기 허용했고, koco-front-s3는 CloudFront 연동을 고려하여 정적 웹 호스팅 설정 및 퍼블릭 접근 허용했습니다.

- CloudFront OAI 연동은 별도 이슈로 분리하여 진행할 예정입니다.

## 📋 작업할 내용
- [ ]  프로필 이미지 저장용 S3 버킷 생성 (koco-img-s3)
- [ ]  프론트엔드 배포용 S3 버킷 생성 (koco-front-s3)
- [ ]  정적 웹 호스팅 활성화 (index.html 기반 SPA 지원)
- [ ]  각 버킷에 lifecycle.prevent_destroy 설정
- [ ]  퍼블릭 접근 허용을 위한 bucket policy 및 public access block 구성
- [ ]  Terraform 모듈 구조화 및 변수 정의

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
