### PR TITLE
Feat: CloudFront + S3(정적 파일) CDN 구성

### DIFF
--- a/Terraform_Project/environments/dev/main.tf
+++ b/Terraform_Project/environments/dev/main.tf
@@ -35,7 +35,17 @@ module "alb" {
   security_group_ids = [module.security_groups.sg_alb.id]
   subnet_ids = module.network.private_app_subnet_ids
   vpc_id = module.network.vpc_id
-  certificate_arn = var.certificate_arn
+}
+
+module "s3_static_site" {
+  source              = "../../modules/s3_static_site"
+  cloudfront_oai_arn  = module.cdn.cloudfront_oai_arn
+}
+
+module "cdn" {
+  source         = "../../modules/cdn"
+  s3_bucket_name = module.s3_static_site.s3_bucket_name
+  alb_dns_name = module.alb.alb_dns_name
 }
 
 # module "asg" {

--- a/Terraform_Project/environments/s3/main.tf
+++ b/Terraform_Project/environments/s3/main.tf
@@ -1,7 +1,3 @@
 module "koco_s3" {
   source = "../../modules/koco_s3"
 }
-
-module "front_s3" {
-  source = "../../modules/front_s3"
-}

--- a/Terraform_Project/modules/alb/outputs.tf
+++ b/Terraform_Project/modules/alb/outputs.tf
@@ -1,3 +1,3 @@
-output "dns_name"{
+output "alb_dns_name"{ #실제 alb 주소
     value = aws_lb.this.dns_name
 }

--- a/Terraform_Project/modules/alb/variables.tf
+++ b/Terraform_Project/modules/alb/variables.tf
@@ -1,3 +1,8 @@
+variable "domain_name" {
+  type = string
+  default = "koco.click"
+}
+
 variable "alb_name" {
   description = "ALB 이름"
   type        = string
@@ -67,11 +72,6 @@ variable "listener_protocol" {
   default     = "HTTP"
 }
 
-variable "certificate_arn" { # 값 넣어 주어야 함
-  description = "Certificate ARN for HTTPS"
-  type        = string
-}
-
 variable "listener_http_name" {
   description = "ALB http 리스너 이름"
   type        = string
@@ -82,4 +82,9 @@ variable "listener_https_name" {
   description = "ALB https 리스너 이름"
   type        = string
   default     = "koco-app-listener-https"
+}
+
+variable "acm_certificate_arn" {
+  type = string
+  default = "arn:aws:acm:ap-northeast-2:266735804784:certificate/6d22a276-2cab-4879-bb1f-10f7ee88621d"
 }

--- a/Terraform_Project/modules/cdn/main.tf
+++ b/Terraform_Project/modules/cdn/main.tf
@@ -1,0 +1,140 @@
+# Route53 Hosted Zone 정보
+data "aws_route53_zone" "main" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+data "aws_region" "current" {}
+
+resource "aws_cloudfront_origin_access_identity" "frontend_oai" {
+  comment = "OAI for frontend S3 access"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Frontend SPA with ALB API routing"
+  default_root_object = var.default_root_object
+
+  aliases = [var.domain_name, "www.${var.domain_name}"]
+
+  # S3 정적 호스팅
+  origin {
+    domain_name = "${var.s3_bucket_name}.s3.${data.aws_region.current.name}.amazonaws.com"
+    origin_id   = "S3-${var.s3_bucket_name}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.frontend_oai.cloudfront_access_identity_path
+    }
+  }
+
+  # SpringBoot
+  origin {
+    domain_name = var.alb_dns_name
+    origin_id   = "ALB-Spring"
+
+    custom_origin_config {
+      http_port              = 8080
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # SpringBoot 요청
+  ordered_cache_behavior {
+    path_pattern     = "/api/*"
+    target_origin_id = "ALB-Spring"
+
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods   = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Authorization"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  # 정적 파일 기본 처리
+  default_cache_behavior {
+    target_origin_id       = "S3-${var.s3_bucket_name}"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/${var.default_root_object}"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/${var.default_root_object}"
+    error_caching_min_ttl = 0
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    Name = "frontend-distribution"
+  }
+}
+
+# Route 53
+resource "aws_route53_record" "cdn_root" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = var.domain_name            # "ktbkoco.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cdn_www" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "www.${var.domain_name}"   # "www.ktbkoco.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/Terraform_Project/modules/cdn/outputs.tf
+++ b/Terraform_Project/modules/cdn/outputs.tf
@@ -1,0 +1,4 @@
+output "cloudfront_oai_arn" {
+  description = "IAM ARN of the CloudFront Origin Access Identity"
+  value       = aws_cloudfront_origin_access_identity.frontend_oai.iam_arn
+}

--- a/Terraform_Project/modules/cdn/variables.tf
+++ b/Terraform_Project/modules/cdn/variables.tf
@@ -1,0 +1,25 @@
+variable "s3_bucket_name" {
+  description = "정적 웹사이트 호스팅용 S3 버킷 이름"
+  type        = string
+}
+
+variable "default_root_object" {
+  description = "CloudFront 기본 루트 객체 (보통 index.html)"
+  type        = string
+  default     = "index.html"
+}
+
+variable "alb_dns_name" {
+  type        = string
+  description = "ALB DNS name for /api traffic"
+}
+
+variable "domain_name" {
+  type    = string
+  default = "koco.click" #	ktbkoco.com
+}
+
+variable "acm_certificate_arn" {
+  type = string
+  default = "arn:aws:acm:us-east-1:266735804784:certificate/8afe7fc4-81f4-4854-a0ce-b4898155aaac"
+}

--- a/Terraform_Project/modules/koco_s3/main.tf
+++ b/Terraform_Project/modules/koco_s3/main.tf
@@ -33,3 +33,18 @@ resource "aws_s3_bucket_policy" "image" {
     ]
   })
 }
+
+resource "aws_s3_bucket_cors_configuration" "image" {
+  bucket = aws_s3_bucket.image.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = [
+      "http://localhost:5173",
+      "https://ktbkoco.com"
+    ]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}

--- a/Terraform_Project/modules/s3_static_site/main.tf
+++ b/Terraform_Project/modules/s3_static_site/main.tf
@@ -1,10 +1,10 @@
 resource "aws_s3_bucket" "frontend" {
   bucket = var.bucket_name 
-  force_destroy = false     # 버킷 비우기 없이 삭제 방지
+  #force_destroy = false     # 버킷 비우기 없이 삭제 방지
 
-  lifecycle {
-    prevent_destroy = true       # 실수로 삭제되는 것 방지
-  }
+  # lifecycle {
+  #   prevent_destroy = true       # 실수로 삭제되는 것 방지
+  # }
 }
 
 resource "aws_s3_bucket_website_configuration" "frontend" {
@@ -23,21 +23,24 @@ resource "aws_s3_bucket_public_access_block" "frontend" {
   bucket = aws_s3_bucket.frontend.id
 
   block_public_acls       = true
-  block_public_policy     = false  # 웹 호스팅을 위해 false
+  block_public_policy     = true  # 웹 호스팅을 위해 false
   ignore_public_acls      = true
-  restrict_public_buckets = false
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_policy" "frontend" {
-  bucket = aws_s3_bucket.frontend.id
+  bucket     = aws_s3_bucket.frontend.id
   depends_on = [aws_s3_bucket_public_access_block.frontend]
+
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
       {
-        Sid       = "PublicReadGetObject",
+        Sid       = "AllowCloudFrontAccess",
         Effect    = "Allow",
-        Principal = "*",
+        Principal = {
+          AWS = var.cloudfront_oai_arn
+        },
         Action    = "s3:GetObject",
         Resource  = "${aws_s3_bucket.frontend.arn}/*"
       }

--- a/Terraform_Project/modules/s3_static_site/outputs.tf
+++ b/Terraform_Project/modules/s3_static_site/outputs.tf
@@ -1,0 +1,7 @@
+output "dns_name" {
+    value = aws_s3_bucket.frontend.bucket_domain_name
+}
+output "s3_bucket_name" {
+  description = "정적 웹사이트 호스팅용 S3 버킷 이름"
+  value       = aws_s3_bucket.frontend.bucket
+}

--- a/Terraform_Project/modules/s3_static_site/variables.tf
+++ b/Terraform_Project/modules/s3_static_site/variables.tf
@@ -3,3 +3,7 @@ variable "bucket_name" {
   type        = string
   default = "koco-front-s3"
 }
+variable "cloudfront_oai_arn" {
+  description = "CloudFront Origin Access Identity의 IAM ARN"
+  type        = string
+}


### PR DESCRIPTION
## 📝 개요
- CloudFront + S3 정적 파일 기반의 CDN 구성을 통해 React 정적 리소스를 전 세계에 빠르게 배포할 수 있도록 개선했습니다.
- 기존 EC2 기반 수동 배포 방식에서 벗어나 정적 리소스에 대해 안정적이고 확장 가능한 구조로 전환했습니다.

## 🔗 연관된 이슈
- #40 

## 🔄 변경사항 및 이유
- aws_cloudfront_distribution, aws_s3_bucket 등 Terraform 코드 추가
- CloudFront에 OAI 설정 및 custom domain 연결 (koco.click, www.koco.click)
- 배포 자동화를 고려해 S3에 접근 권한은 CloudFront OAI로 제한
- 보안성 향상 (HTTPS 적용 및 퍼블릭 접근 차단), 캐시 성능 개선 목적

## 📋 작업할 내용
- [ ] S3 버킷 생성 및 퍼블릭 차단 정책 적용
- [ ] CloudFront 배포 생성 (정적 파일 + ALB 라우팅)
- [ ]  ACM 인증서(us-east-1) 발급 및 DNS 검증 적용
- [ ]  Terraform module 분리 및 리소스 관리
- [ ]  Route53 A 레코드(ALIAS) 생성하여 사용자 도메인 연결
- [ ]  기본 OAI 접근 정책 적용 및 테스트
- [ ]  브라우저 접속 테스트 완료 (https://koco.click) -> 테스트 도메인

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
