### PR TITLE
[FEATURE] Feature/alb v2 (alb 수정 업데이트)

### DIFF
--- a/Terraform_Project/modules/alb/outputs.tf
+++ b/Terraform_Project/modules/alb/outputs.tf
@@ -1,3 +1,34 @@
-output "alb_dns_name"{ #실제 alb 주소
-    value = aws_lb.this.dns_name
+output "alb_arn" {
+  description = "생성된 ALB의 ARN"
+  value       = aws_lb.this.arn
+}
+
+output "alb_dns_name" {
+  description = "생성된 ALB의 DNS 이름"
+  value       = aws_lb.this.dns_name
+}
+
+output "target_group_blue_arn" {
+  description = "생성된 ALB Blue 대상 그룹의 ARN"
+  value       = aws_lb_target_group.blue.arn
+}
+
+output "target_group_blue_name" {
+  description = "생성된 ALB Blue 대상 그룹의 name"
+  value       = aws_lb_target_group.blue.name
+}
+
+output "target_group_green_arn" {
+  description = "생성된 ALB Green 대상 그룹의 ARN"
+  value       = aws_lb_target_group.green.arn
+}
+
+output "target_group_green_name" {
+  description = "생성된 ALB Green 대상 그룹의 name"
+  value       = aws_lb_target_group.green.name
+}
+
+output "listener_arn" {
+  description = "생성된 ALB 리스너의 ARN"
+  value       = aws_lb_listener.https.arn
 }

--- a/Terraform_Project/modules/alb/variables.tf
+++ b/Terraform_Project/modules/alb/variables.tf
@@ -3,10 +3,15 @@ variable "domain_name" {
   default = "koco.click"
 }
 
+variable "environment" {
+  description = "환경 이름 (예: dev, stage, prod)"
+  type        = string
+}
+
 variable "alb_name" {
   description = "ALB 이름"
   type        = string
-  default     = "koco-app-alb"
+  default     = "app-alb"
 }
 
 variable "subnet_ids" {
@@ -27,7 +32,7 @@ variable "vpc_id" {
 variable "target_group_name" {
   description = "ALB 대상 그룹 이름"
   type        = string
-  default     = "koco-app"
+  default     = "app-tg"
 }
 
 variable "target_group_port" {
@@ -45,7 +50,7 @@ variable "target_group_protocol" {
 variable "health_check_path" {
   description = "헬스 체크 경로"
   type        = string
-  default     = "/health"
+  default     = "/"
 }
 
 variable "health_check_protocol" {
@@ -72,19 +77,7 @@ variable "listener_protocol" {
   default     = "HTTP"
 }
 
-variable "listener_http_name" {
-  description = "ALB http 리스너 이름"
-  type        = string
-  default     = "koco-app-listener-http"
-}
-
-variable "listener_https_name" {
-  description = "ALB https 리스너 이름"
-  type        = string
-  default     = "koco-app-listener-https"
-}
-
 variable "acm_certificate_arn" {
   type = string
-  default = "arn:aws:acm:ap-northeast-2:266735804784:certificate/6d22a276-2cab-4879-bb1f-10f7ee88621d"
+  default = "arn:aws:acm:ap-northeast-2:266735804784:certificate/c29976ee-8091-402e-b321-486a0884b60a"
 }


### PR DESCRIPTION
## 📝 개요
- 기존 ALB 코드에 Blue-Green 배포 전략을 적용하기 위한 리팩토링 및 설정 추가

## 🔗 연관된 이슈
- #123 (예: Blue/Green 배포 구조 설계)
- #456 (예: ALB 리스너 설정 버그 수정)

## 🔄 변경사항 및 이유
- 기존 `aws_lb` 리소스를 리팩토링하여 Blue-Green 배포를 위한 대상 그룹(`tg-blue`, `tg-green`) 구성 추가
- `aws_lb_listener` 리소스를 추가하여 HTTPS 리스너 구성 및 기본 대상 그룹 연결
- 향후 트래픽 조건 분기를 위한 `aws_lb_listener_rule` 확장 가능 구조로 설계
- 무중단 배포(Blue/Green)를 위한 인프라 구조 개선 목적

## 📋 작업할 내용
- [x] 기능 세부 요구사항 정리
- [x] ALB + Blue/Green 배포 구조 설계
- [x] Terraform 코드 작성 및 테스트
- [x] 기존 리소스와의 충돌 방지 처리
- [ ] 배포 후 실제 트래픽 분기 확인

## 🔖 기타사항
- [x] 성능 고려 필요 (헬스체크 경로 설정 및 대상 그룹 기준 설정)
- [x] 보안 고려 필요 (HTTPS 리스너 인증서 적용 및 TLS 정책 적용)
- [ ] 외부 라이브러리 사용 없음
- [ ] 추가 논의가 필요한 이슈 있음 (리스너 규칙에 따른 대상 전환 정책)

## 👀 리뷰 요구사항 (선택)
- Blue-Green 대상 그룹 설정 방식이 명확한지 검토 부탁드립니다
- 리스너 정책 설정(기본 target group vs 규칙 기반 전환)에 대한 의견 요청

## 🔗 참고 자료 (선택)
- [AWS Blue-Green 배포 공식 문서](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-groups-create-blue-green.html)
- [Terraform ALB Module 예시](https://registry.terraform.io/modules/terraform-aws-modules/alb/aws/latest)
