### PR TITLE
FEATURE: add ASG, CodeDeploy, EC2, ECR, IAM, and update security groups

### DIFF
--- a/Terraform_Project/backend/main.tf
+++ b/Terraform_Project/backend/main.tf
@@ -1,3 +1,9 @@
+####################################
+# 테라폼 상태저장을 aws s3와 DynamoDB로 관리하기 위한 설정 테라폼 실행 파일
+  # 이 파일을 통해 테라폼 상태를 관리하는 s3와 DynamoDB가 생성된다.
+  # 이 파일을 terraform apply 한 후 dev/main or prod/main 을 terraform apply 해야한다.
+####################################
+
 resource "aws_s3_bucket" "terraform_state" { 
   bucket = "evan-terraformstate"
   force_destroy = false

--- a/Terraform_Project/environments/dev/main.tf
+++ b/Terraform_Project/environments/dev/main.tf
@@ -19,24 +19,6 @@ module "network" {
   ]
 }
 
-module "security_groups" {
-  source = "../../modules/security_groups"
-  vpc_id = module.network.vpc_id
-}
-
-module "openvpn" {
-  source = "../../modules/openvpn"
-  subnet_id               = module.network.public_subnet_ids[0]
-  vpc_security_group_ids  = [module.security_groups.sg_openvpn.id]
-}
-
-module "alb" {
-  source = "../../modules/alb"
-  security_group_ids = [module.security_groups.sg_alb.id]
-  subnet_ids = module.network.private_app_subnet_ids
-  vpc_id = module.network.vpc_id
-}
-
 module "s3_static_site" {
   source              = "../../modules/s3_static_site"
   cloudfront_oai_arn  = module.cdn.cloudfront_oai_arn
@@ -48,25 +30,95 @@ module "cdn" {
   alb_dns_name = module.alb.alb_dns_name
 }
 
-# module "asg" {
-#   source = "../modules/asg"
 
-#   environment           = "dev"
-#   asg_name              = "app-asg-dev"
-#   vpc_zone_identifier   = module.network.private_app_subnet_ids
-#   launch_template_id    = module.ec2.launch_template_id
-#   launch_template_version = "$Latest"
-#   desired_capacity      = 2
-#   min_size              = 2
-#   max_size              = 4
-#   target_group_arns     = [module.alb.target_group_arn] // 아직 alb 모듈 생성전 생성 후 추가
-#   health_check_type         = "EC2"
-#   health_check_grace_period = 300
-#   instance_tag_name     = "app-instance"
+module "ecr" {
+  source           = "../../modules/ecr"
+  repository_name  = "app-repo"
+  tags = {
+    Name        = "App Repo"
+    Environment = "Production"
+  }
+}
 
-#   depends_on = [
-#     module.network,  // network 모듈이 완료된 후 실행
-#     module.alb,      // alb 모듈이 완료된 후 실행
-#     module.ec2       // ec2 모듈이 완료된 후 실행
-#   ]
-# }
+module "iam" {
+  source = "../../modules/iam"
+
+  # 필요시 변수 값을 오버라이드할 수 있습니다.
+  codedeploy_role_name       = "MyCodeDeployRole"
+  ec2_role_name              = "MyEC2Role"
+  ec2_instance_profile_name  = "MyEC2InstanceProfile"
+}
+
+
+module "security_groups" {
+  source = "../../modules/security_groups"
+  vpc_id = module.network.vpc_id
+}
+
+module "codedeploy" {
+  source                = "../../modules/codedeploy"
+  app_name              = "was-deploy-app"
+  deployment_group_name = "was-deploy-group"
+  service_role_arn      = module.iam.codedeploy_role_arn
+  target_group_blue_name = module.alb.target_group_blue_name
+  target_group_green_name = module.alb.target_group_green_name
+  alb_listener_arn       = module.alb.listener_arn
+  autoscaling_groups    = [module.asg.asg_name]
+
+  depends_on = [
+    module.iam,  // iam 모듈이 완료된 후 실행
+    module.alb,      // alb 모듈이 완료된 후 실행
+    module.asg       // asg 모듈이 완료된 후 실행
+  ]
+}
+
+module "ec2" {
+  source = "../../modules/ec2"
+
+  instance_type              = "t3.micro"
+  key_name                   = "KoCo_testServer_key"
+  iam_instance_profile_name  = module.iam.ec2_instance_profile_name
+  security_group_ids         = [module.security_groups.app_sg_id]
+  # user_data는 기본값을 사용하거나 별도로 수정 가능
+}
+
+module "asg" {
+  source = "../../modules/asg"
+
+  environment           = "dev"
+  asg_name              = "app-asg-dev"
+  vpc_zone_identifier   = module.network.private_app_subnet_ids
+  launch_template_id    = module.ec2.launch_template_id
+  launch_template_version = "$Latest"
+  desired_capacity      = 1
+  min_size              = 1
+  max_size              = 1
+  target_group_arns     = module.alb.target_group_blue_arn
+  health_check_type         = "EC2"
+  health_check_grace_period = 300
+  instance_tag_name     = "app-instance"
+
+  depends_on = [
+    module.network,  // network 모듈이 완료된 후 실행
+    module.alb,      // alb 모듈이 완료된 후 실행
+    module.ec2       // ec2 모듈이 완료된 후 실행
+  ]
+
+}
+
+module "alb" {
+  source              = "../../modules/alb"
+  environment         = "dev"
+  alb_name            = "app-alb"
+  subnet_ids          = module.network.public_subnet_ids  # 네트워크 모듈의 출력값 사용 가능
+  security_group_ids  = [module.security_groups.alb_sg_id]                   # ALB 전용 보안 그룹
+  vpc_id              = module.network.vpc_id                                 # 네트워크 모듈의 VPC ID 사용
+  # 나머지 변수들은 기본값 사용 (필요시 tfvars 또는 직접 값 지정)
+}
+
+
+module "openvpn" {
+  source = "../../modules/openvpn"
+  subnet_id               = module.network.public_subnet_ids[0]
+  vpc_security_group_ids  = [module.security_groups.openvpn_sg_id]
+}

--- a/Terraform_Project/modules/asg/main.tf
+++ b/Terraform_Project/modules/asg/main.tf
@@ -1,0 +1,28 @@
+resource "aws_autoscaling_group" "this" {
+  name                = var.asg_name
+  desired_capacity    = var.desired_capacity
+  max_size            = var.max_size
+  min_size            = var.min_size
+  vpc_zone_identifier = var.vpc_zone_identifier     #  인스턴스가 자동 분산 배치됨
+
+  launch_template {
+    id      = var.launch_template_id
+    version = var.launch_template_version
+  }
+
+  target_group_arns         = [var.target_group_arns] # 인프라 첫구성 블루 대상그룹 연결
+  health_check_type         = var.health_check_type
+  health_check_grace_period = var.health_check_grace_period
+
+
+
+  tag {
+    key                 = "Name"
+    value               = var.instance_tag_name
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true   # 배포 시 무중단 되도록 기존 인스턴스 삭제 전 새로 생성
+  }
+}

--- a/Terraform_Project/modules/asg/outputs.tf
+++ b/Terraform_Project/modules/asg/outputs.tf
@@ -1,0 +1,9 @@
+output "asg_name" {
+  description = "생성된 Auto Scaling Group의 이름"
+  value       = aws_autoscaling_group.this.name
+}
+
+output "asg_arn" {
+  description = "생성된 Auto Scaling Group의 ARN"
+  value       = aws_autoscaling_group.this.arn
+}

--- a/Terraform_Project/modules/asg/variables.tf
+++ b/Terraform_Project/modules/asg/variables.tf
@@ -1,0 +1,63 @@
+variable "environment" {
+  description = "환경 이름 (예: dev, stage, prod)"
+  type        = string
+}
+
+variable "asg_name" {
+  description = "Auto Scaling Group 이름 (접두어)"
+  type        = string
+}
+
+variable "vpc_zone_identifier" {
+  description = "ASG가 배포될 프라이빗 서브넷 ID 목록"
+  type        = list(string)
+}
+
+variable "launch_template_id" {
+  description = "EC2 인스턴스용 Launch Template ID"
+  type        = string
+}
+
+variable "launch_template_version" {
+  description = "Launch Template 버전"
+  type        = string
+  default     = "$Latest"
+}
+
+variable "desired_capacity" {
+  description = "ASG 원하는 인스턴스 수"
+  type        = number
+}
+
+variable "min_size" {
+  description = "ASG 최소 인스턴스 수"
+  type        = number
+}
+
+variable "max_size" {
+  description = "ASG 최대 인스턴스 수"
+  type        = number
+}
+
+variable "target_group_arns" {
+  description = "ASG에 연결할 ALB Target Group ARN 목록"
+  type        = string
+}
+
+variable "health_check_type" {
+  description = "헬스체크 타입 (예: EC2, ELB)"
+  type        = string
+  default     = "EC2"
+}
+
+variable "health_check_grace_period" {
+  description = "헬스체크 유예기간 (초)"
+  type        = number
+  default     = 300
+}
+
+variable "instance_tag_name" {
+  description = "ASG 인스턴스에 부여할 Name 태그 값"
+  type        = string
+  default     = "app-instance"
+}

--- a/Terraform_Project/modules/codedeploy/main.tf
+++ b/Terraform_Project/modules/codedeploy/main.tf
@@ -1,0 +1,70 @@
+##############################
+# 6. CodeDeploy Application & Deployment Group
+##############################
+resource "aws_codedeploy_app" "was_app" {
+  name             = "was-deploy-app"
+  compute_platform = "Server"
+}
+
+resource "aws_codedeploy_deployment_group" "was_dg" {
+  app_name              = aws_codedeploy_app.was_app.name
+  deployment_group_name = "was-deploy-group"
+  service_role_arn      = var.service_role_arn
+
+  deployment_style {
+    deployment_type   = "BLUE_GREEN"
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+  }
+
+  blue_green_deployment_config {
+    green_fleet_provisioning_option {
+      action = "COPY_AUTO_SCALING_GROUP"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+
+    deployment_ready_option {
+      action_on_timeout    = "CONTINUE_DEPLOYMENT"
+      wait_time_in_minutes = 0
+    }
+  }
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  load_balancer_info {
+    # 💡 핵심: CodeDeploy가 이 블록을 통해 대상 그룹과의 연결을 확실히 인식
+    target_group_pair_info {
+      target_group {
+        name = "tg-blue"
+      }
+      target_group {
+        name = "tg-green"
+      }
+
+      prod_traffic_route {
+        listener_arns = [var.alb_listener_arn]
+      }
+
+      test_traffic_route {
+        listener_arns = [var.alb_listener_arn]
+      }
+    }
+
+    # ✅ 명시적으로 각 대상 그룹을 등록 !!반드시 필요!!
+    target_group_info {
+      name = "tg-blue"
+    }
+
+    target_group_info {
+      name = "tg-green"
+    }
+  }
+
+  autoscaling_groups = var.autoscaling_groups
+}

--- a/Terraform_Project/modules/codedeploy/outputs.tf
+++ b/Terraform_Project/modules/codedeploy/outputs.tf
@@ -1,0 +1,9 @@
+output "codedeploy_app_name" {
+  description = "생성된 CodeDeploy 애플리케이션 이름"
+  value       = aws_codedeploy_app.was_app.name
+}
+
+output "codedeploy_deployment_group_name" {
+  description = "생성된 CodeDeploy 배포 그룹 이름"
+  value       = aws_codedeploy_deployment_group.was_dg.deployment_group_name
+}

--- a/Terraform_Project/modules/codedeploy/variables.tf
+++ b/Terraform_Project/modules/codedeploy/variables.tf
@@ -1,0 +1,53 @@
+variable "app_name" {
+  description = "CodeDeploy 애플리케이션 이름"
+  type        = string
+}
+
+variable "deployment_group_name" {
+  description = "CodeDeploy 배포 그룹 이름"
+  type        = string
+}
+
+variable "service_role_arn" {
+  description = "CodeDeploy 배포에 사용할 IAM 역할 ARN"
+  type        = string
+}
+
+variable "autoscaling_groups" {
+  description = "배포 대상으로 사용할 Auto Scaling Group 이름 목록"
+  type        = list(string)
+}
+
+variable "alb_listener_arn" {
+  description = "alb_listener_arn"
+  type        = string
+}
+
+variable "deployment_config_name" {
+  description = "배포 구성 이름 (예: CodeDeployDefault.OneAtATime)"
+  type        = string
+  default     = "CodeDeployDefault.OneAtATime"
+}
+
+variable "auto_rollback_enabled" {
+  description = "자동 롤백 활성화 여부"
+  type        = bool
+  default     = true
+}
+
+variable "auto_rollback_events" {
+  description = "자동 롤백 시 동작할 이벤트 목록"
+  type        = list(string)
+  default     = ["DEPLOYMENT_FAILURE"]
+}
+
+variable "target_group_blue_name" {
+  description = "blue 대상 그룹 이름"
+  type = string
+}
+
+
+variable "target_group_green_name" {
+  description = "green 대상 그룹 이름"
+  type = string
+}

--- a/Terraform_Project/modules/ec2/main.tf
+++ b/Terraform_Project/modules/ec2/main.tf
@@ -1,0 +1,46 @@
+# Launch Template 생성
+resource "aws_launch_template" "app_lt" {
+  name_prefix   = "was-launch-template-"
+  image_id      = "ami-05a7f3469a7653972"  # ✅ 여기 직접 지정
+
+  instance_type = var.instance_type         # EC2 타입도 변수로 주입
+  key_name      = var.key_name          # SSH 접근을 위한 키페어
+
+  iam_instance_profile {
+    name = var.iam_instance_profile_name    # EC2에 연결할 IAM Role
+  }
+
+  user_data = base64encode(var.user_data)       # 초기 부팅 시 실행할 스크립트
+
+  vpc_security_group_ids = var.security_group_ids       # 보안 그룹 설정
+
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "AppInstance"
+    }
+  }
+}
+
+
+# ----------------------------
+##############################
+# 1. Launch Template
+##############################
+# resource "aws_launch_template" "was_template" {
+#   name_prefix   = "was-launch-template-"
+#   image_id      = var.ami_id                         # 사용할 AMI ID
+#   instance_type = "t3.micro"
+
+#   iam_instance_profile {
+#     name = var.instance_profile_name                 # EC2 인스턴스에 연결할 IAM 역할
+#   }
+
+#    {
+#     associate_public_ip_address = false              # 퍼블릭 IP 비활성화 (프라이빗 서브넷)
+#     security_groups             = [var.security_group_id]
+#   }
+
+#   user_data = base64encode(file("scripts/user_data.sh"))  # 초기 실행 스크립트
+# }

--- a/Terraform_Project/modules/ec2/outputs.tf
+++ b/Terraform_Project/modules/ec2/outputs.tf
@@ -1,0 +1,4 @@
+output "launch_template_id" {
+  description = "생성된 Launch Template ID"
+  value       = aws_launch_template.app_lt.id
+}

--- a/Terraform_Project/modules/ec2/variables.tf
+++ b/Terraform_Project/modules/ec2/variables.tf
@@ -1,0 +1,78 @@
+variable "instance_type" {
+  description = "EC2 인스턴스 타입 (예: t3.micro)"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "key_name" {
+  description = "SSH 키 페어 이름"
+  type        = string
+  default     = "KoCo_testServer_key"
+}
+
+variable "iam_instance_profile_name" {
+  description = "EC2 인스턴스에 연결할 IAM 인스턴스 프로파일 이름"
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "EC2 인스턴스에 적용할 보안 그룹 ID 목록"
+  type        = list(string)
+}
+
+variable "user_data" {
+  description = "EC2 인스턴스 부팅 시 실행할 user_data 스크립트 (base64 인코딩 필요 없음)"
+  type        = string
+  default     = <<-EOF
+    #!/bin/bash
+    set -e
+
+    #-------------------------------
+    # 시스템 패키지 업데이트
+    #-------------------------------
+    apt-get update -y
+    apt-get upgrade -y
+
+    #-------------------------------
+    # CodeDeploy 에이전트 설치
+    #-------------------------------
+    apt-get install -y ruby wget
+    cd /home/ubuntu
+    wget https://aws-codedeploy-ap-northeast-2.s3.amazonaws.com/latest/install
+    chmod +x ./install
+    ./install auto
+    systemctl start codedeploy-agent
+    systemctl enable codedeploy-agent
+
+    #-------------------------------
+    # Docker 설치 및 설정
+    #-------------------------------
+    apt-get install -y \
+      ca-certificates \
+      curl \
+      gnupg \
+      lsb-release
+
+    mkdir -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+      https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+      | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    apt-get update -y
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+    systemctl start docker
+    systemctl enable docker
+    usermod -aG docker ubuntu
+
+    #-------------------------------
+    # Docker Compose 설치
+    #-------------------------------
+    curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" \
+      -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+  EOF
+}

--- a/Terraform_Project/modules/ecr/main.tf
+++ b/Terraform_Project/modules/ecr/main.tf
@@ -1,0 +1,12 @@
+resource "aws_ecr_repository" "this" {
+  name                  = var.repository_name
+  image_tag_mutability  = var.image_tag_mutability
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  tags = merge({
+    Name = var.repository_name
+  }, var.tags)
+}

--- a/Terraform_Project/modules/ecr/outputs.tf
+++ b/Terraform_Project/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "생성된 ECR 리포지토리의 URL"
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = "생성된 ECR 리포지토리의 ARN"
+  value       = aws_ecr_repository.this.arn
+}

--- a/Terraform_Project/modules/ecr/variables.tf
+++ b/Terraform_Project/modules/ecr/variables.tf
@@ -1,0 +1,24 @@
+variable "repository_name" {
+  description = "생성할 ECR 리포지토리 이름"
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = "이미지 태그 변경 가능 여부 (MUTABLE 또는 IMMUTABLE)"
+  type        = string
+  default     = "MUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "이미지 푸시 시 스캔 여부"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "리포지토리에 적용할 태그"
+  type        = map(string)
+  default     = {
+    Environment = "Production"
+  }
+}

--- a/Terraform_Project/modules/iam/main.tf
+++ b/Terraform_Project/modules/iam/main.tf
@@ -1,0 +1,104 @@
+########################################
+# CodeDeploy IAM 역할 생성 및 정책 첨부
+########################################
+
+resource "aws_iam_role" "codedeploy_role" {
+  name = var.codedeploy_role_name
+
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17",
+    Statement = [{
+      Action    = "sts:AssumeRole",
+      Effect    = "Allow",
+      Principal = {
+        Service = "codedeploy.amazonaws.com"
+      }
+    }]
+  })
+}
+
+# AWS 기본 제공 정책 - CodeDeploy 실행용
+resource "aws_iam_role_policy_attachment" "codedeploy_role_policy" {
+  role       = aws_iam_role.codedeploy_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+}
+
+# AWS 기본 제공 정책 - CodeDeploy 콘솔 제어용 (선택사항)
+resource "aws_iam_role_policy_attachment" "codedeploy_codedeploy_full_policy" {
+  role       = aws_iam_role.codedeploy_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess"
+}
+
+# ✅ 사용자 정의 정책 - Blue/Green 배포를 위한 추가 권한
+resource "aws_iam_policy" "codedeploy_bluegreen_policy" {
+  name = "CodeDeployBlueGreenPolicy"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ec2:Describe*",
+          "elasticloadbalancing:Describe*",
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "autoscaling:UpdateAutoScalingGroup",
+          "autoscaling:Describe*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy_bluegreen_policy_attach" {
+  role       = aws_iam_role.codedeploy_role.name
+  policy_arn = aws_iam_policy.codedeploy_bluegreen_policy.arn
+}
+
+
+########################################
+# EC2 인스턴스 IAM 역할 생성 및 정책 첨부
+########################################
+
+resource "aws_iam_role" "ec2_role" {
+  name = var.ec2_role_name
+
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17",
+    Statement = [{
+      Action    = "sts:AssumeRole",
+      Effect    = "Allow",
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_s3_full_access" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_codedeploy_full_access" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_ecr_full_access" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+}
+
+########################################
+# EC2 인스턴스 프로파일 생성
+########################################
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = var.ec2_instance_profile_name
+  role = aws_iam_role.ec2_role.name
+}

--- a/Terraform_Project/modules/iam/outputs.tf
+++ b/Terraform_Project/modules/iam/outputs.tf
@@ -1,0 +1,14 @@
+output "codedeploy_role_arn" {
+  description = "CodeDeploy IAM 역할 ARN"
+  value       = aws_iam_role.codedeploy_role.arn
+}
+
+output "ec2_role_arn" {
+  description = "EC2 인스턴스용 IAM 역할 ARN"
+  value       = aws_iam_role.ec2_role.arn
+}
+
+output "ec2_instance_profile_name" {
+  description = "EC2 인스턴스 프로파일 이름"
+  value       = aws_iam_instance_profile.ec2_profile.name
+}

--- a/Terraform_Project/modules/iam/variables.tf
+++ b/Terraform_Project/modules/iam/variables.tf
@@ -1,0 +1,17 @@
+variable "codedeploy_role_name" {
+  description = "CodeDeploy IAM 역할 이름"
+  type        = string
+  default     = "CodeDeployServiceRole"
+}
+
+variable "ec2_role_name" {
+  description = "EC2 인스턴스용 IAM 역할 이름"
+  type        = string
+  default     = "MyEC2Role"
+}
+
+variable "ec2_instance_profile_name" {
+  description = "EC2 인스턴스 프로파일 이름"
+  type        = string
+  default     = "MyEC2InstanceProfile"
+}

--- a/Terraform_Project/modules/koco_s3/main.tf
+++ b/Terraform_Project/modules/koco_s3/main.tf
@@ -1,3 +1,9 @@
+####################################
+# 이미지 저장 버킷 생성 코드로 dev/main.tf의 모듈이 실행되지 않고, 
+# 21-iceT-cloud/Terraform_Project/environments/s3 폴더에서 개별적으로 실행된다
+# 즉 dev/main.tf을 terraform destroy해도 삭제되지 않음
+####################################
+
 resource "aws_s3_bucket" "image" {
   bucket = var.bucket_name
   force_destroy = false     # 버킷 비우기 없이 삭제 방지

--- a/Terraform_Project/modules/security_groups/main.tf
+++ b/Terraform_Project/modules/security_groups/main.tf
@@ -1,36 +1,54 @@
-resource "aws_security_group" "sg_openvpn" { # openvpn 보안 그룹
-    name   = "sg_openvpn"
-    vpc_id = var.vpc_id
+########################################
+# OpenVPN 서버용 보안 그룹 생성
+########################################
 
-    ingress { 
-        from_port = 22
-        to_port = 22
-        protocol = "tcp"
-        cidr_blocks = [ "0.0.0.0/0" ]
-    }
+resource "aws_security_group" "openvpn_sg" {
+  name        = "openvpn-sg"
+  description = "Security group for OpenVPN server"
+  vpc_id      = var.vpc_id
 
-    ingress { 
-        from_port = 443
-        to_port = 443
-        protocol = "tcp"
-        cidr_blocks = [ "0.0.0.0/0" ]
-    }
+  ingress {
+    description = "Allow OpenVPN UDP(1194) traffic"
+    from_port   = 1194
+    to_port     = 1194
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-    ingress {
-      from_port = 1194
-        to_port = 1194
-        protocol = "udp"
-        cidr_blocks = [ "0.0.0.0/0" ]
-    }
+  ingress {
+    description = "Allow SSH(22) access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-    ingress {
-      from_port = 943
-        to_port = 943
-        protocol = "tcp"
-        cidr_blocks = [ "0.0.0.0/0" ]
-    }
+  ingress {
+    description = "Allow TCP(945) access"
+    from_port   = 945
+    to_port     = 945
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-    egress { 
+  ingress {
+    description = "Allow HTTPS(443) access"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow TCP(943) access"
+    from_port   = 943
+    to_port     = 943
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
@@ -38,24 +56,27 @@ resource "aws_security_group" "sg_openvpn" { # openvpn 보안 그룹
   }
 }
 
-resource "aws_security_group" "sg_alb" { # alb 보안 그룹
-  name   = "sg_alb"
-  description = "Allow HTTP and HTTPS inbound traffic to ALB"
-  vpc_id = var.vpc_id
+########################################
+# ALB용 보안 그룹 생성
+########################################
+
+resource "aws_security_group" "alb_sg" {
+  name        = "alb-sg"
+  description = "Security group for Application Load Balancer"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port   = 443
     to_port     = 443
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"] 
-    description = ""
-  }
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "TCP"
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-    description = ""
   }
 
   egress {
@@ -63,5 +84,74 @@ resource "aws_security_group" "sg_alb" { # alb 보안 그룹
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+########################################
+# 애플리케이션 서버용 보안 그룹 생성
+########################################
+
+resource "aws_security_group" "app_sg" {
+  name        = "app-sg"
+  description = "Security group for application servers, allow traffic only from ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]  # ALB 보안 그룹에서 오는 트래픽만 허용
+  }
+
+  ingress {
+    description     = "Allow SSH (port 22) from OpenVPN clients"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.openvpn_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+########################################
+# RDS 전용 보안 그룹 생성
+########################################
+
+resource "aws_security_group" "rds_sg" {
+  name        = "rds_sg"
+  description = "Allow DB access from APP instances"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app_sg.id]
+    description     = "Allow MySQL access from APP instances"
+  }
+
+  ingress {
+    description     = "Allow 3306 from OpenVPN clients"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.openvpn_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "RDS Security Group"
   }
 }

--- a/Terraform_Project/modules/security_groups/outputs.tf
+++ b/Terraform_Project/modules/security_groups/outputs.tf
@@ -1,7 +1,19 @@
-output "sg_openvpn" {
-  value = aws_security_group.sg_openvpn
+output "openvpn_sg_id" {
+  description = "OpenVPN 서버 보안 그룹 ID"
+  value       = aws_security_group.openvpn_sg.id
 }
 
-output "sg_alb" {
-  value = aws_security_group.sg_alb
+output "alb_sg_id" {
+  description = "ALB 보안 그룹 ID"
+  value       = aws_security_group.alb_sg.id
+}
+
+output "app_sg_id" {
+  description = "애플리케이션 서버 보안 그룹 ID"
+  value       = aws_security_group.app_sg.id
+}
+
+output "rds_sg_id" {
+  description = "RDS 전용 보안 그룹 ID"
+  value       = aws_security_group.rds_sg.id
 }

--- a/Terraform_Project/modules/security_groups/variables.tf
+++ b/Terraform_Project/modules/security_groups/variables.tf
@@ -1,3 +1,4 @@
 variable "vpc_id" {
-    type = string
+  description = "보안 그룹을 생성할 VPC ID"
+  type        = string
 }


### PR DESCRIPTION
## 📝 개요
- Terraform을 활용해 EC2 기반 Blue/Green 배포를 위한 인프라 구성 요소를 추가했습니다.
- Auto Scaling Group, CodeDeploy, EC2, ECR, IAM, Security Group 등을 포함합니다.

## 🔗 연관된 이슈
- #123 인프라 배포 자동화 구성
- #126 CodeDeploy Blue/Green 전략 적용

## 🔄 변경사항 및 이유
- ASG 리소스 추가: Blue/Green 배포를 위한 인스턴스 그룹 구성
- CodeDeploy 설정 추가: 배포 그룹, 서비스 역할, AppSpec 구성 대응
- EC2 Launch Template 및 관련 리소스 생성
- ECR 저장소 추가: 도커 이미지 푸시 및 배포를 위한 저장소
- IAM 역할 및 인스턴스 프로파일 추가: EC2 및 CodeDeploy에 필요한 권한 부여
- Security Group 업데이트: EC2 및 ALB에 필요한 포트 허용

이러한 변경을 통해 코드 기반 인프라 관리가 가능해지며, 배포 자동화를 위한 기반이 마련됩니다.

## 📋 작업할 내용
- [x] 기능 세부 요구사항 정리
- [ ] API 설계
- [ ] UI/UX 설계
- [ ] 프론트엔드 구현
- [ ] 백엔드 구현
- [x] 테스트 코드 작성 (Terraform validate, plan)
- [x] 배포 및 적용 확인

## 🔖 기타사항
- [ ] 추가 논의가 필요한 이슈 있음
- [ ] 외부 라이브러리 사용 예정
- [x] 성능 고려 필요 (ASG 스케일 정책 등)
- [x] 보안 고려 필요 (IAM 최소 권한, 보안 그룹 설정 등)

## 👀 리뷰 요구사항 (선택)
- Terraform 리소스 구성 방식 및 네이밍 컨벤션에 대한 의견
- CodeDeploy 설정이 Blue/Green 전략에 적절하게 구성되었는지 확인 부탁드립니다.

## 🔗 참고 자료 (선택)
- [AWS Blue/Green 배포 개요](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-groups.html)
- [Terraform AWS Provider Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
