### PR TITLE
[FEATURE] waf 연결

### DIFF
--- a/Terraform_Project/modules/cdn/main.tf
+++ b/Terraform_Project/modules/cdn/main.tf
@@ -109,6 +109,9 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
   }
 
+  # cloudFront WAF 연결
+  web_acl_id = "arn:aws:wafv2:us-east-1:266735804784:global/webacl/secure-waf/75fa0fac-0e8e-4e42-9b10-6297b45891c1"
+
   tags = {
     Name = "frontend-distribution"
   }


### PR DESCRIPTION
## 📝 개요
- CloudFront 모듈에 기존에 생성된 WAF(Web ACL)를 연결하는 설정(`web_acl_id`)을 추가했습니다.

## 🔗 연관된 이슈
- #보안강화
- #CloudFront-WAF-연동

## 🔄 변경사항 및 이유
- `web_acl_id = "<WAF ARN>"`을 CloudFront 배포 설정에 추가
- CloudFront 배포에 보안 규칙(WAF)을 적용하여 SQL/XSS, 봇 트래픽, 해외 접근 등의 위협을 사전에 차단하기 위함입니다.

## 📋 작업할 내용
- [x] WAF Web ACL ARN 확인
- [x] CloudFront 모듈 내 `web_acl_id` 설정 추가
- [x] Terraform apply 수행 및 연결 확인
- [ ] 테스트 트래픽으로 WAF 차단 로그 검증

## 🔖 기타사항
- [x] 보안 고려 필요
- [ ] 추가 논의가 필요한 이슈 있음

## 👀 리뷰 요구사항 (선택)
- WAF 연결이 잘못되었을 경우 CloudFront 배포가 실패할 수 있으므로 `terraform plan` 결과 확인 부탁드립니다.

## 🔗 참고 자료 (선택)
- [AWS 공식 문서: WAF와 CloudFront 통합](https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-associating-cloudfront.html)
