### PR TITLE
[FEATURE] EC2 IAM role에 SSM parameter 읽기 권한 추가

### DIFF
--- a/Terraform_Project/modules/iam/main.tf
+++ b/Terraform_Project/modules/iam/main.tf
@@ -79,6 +79,24 @@ resource "aws_iam_role" "ec2_role" {
   })
 }
 
+resource "aws_iam_policy" "ssm_parameter_read" {
+  name        = "EC2SSMParameterReadPolicy"
+  description = "Allow EC2 instance to read SSM parameters for /spring path"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ssm:GetParametersByPath"
+        ],
+        Resource = "arn:aws:ssm:ap-northeast-2:266735804784:parameter/spring/*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy_attachment" "ec2_s3_full_access" {
   role       = aws_iam_role.ec2_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
@@ -93,6 +111,12 @@ resource "aws_iam_role_policy_attachment" "ec2_ecr_full_access" {
   role       = aws_iam_role.ec2_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "ec2_ssm_parameter_read_attach" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.ssm_parameter_read.arn
+}
+
 
 ########################################
 # EC2 인스턴스 프로파일 생성


### PR DESCRIPTION
## 📝 개요
- EC2 인스턴스가 AWS SSM Parameter Store에서 환경변수를 읽을 수 있도록 IAM 권한을 추가했습니다.

## 🔗 연관된 이슈

## 🔄 변경사항 및 이유
- `aws_iam_policy` 리소스를 추가하여 `/spring/*` 경로의 파라미터에 대한 `ssm:GetParametersByPath` 권한을 명시
- 해당 정책을 EC2용 IAM Role에 attach하여, EC2 인스턴스에서 `.env` 파일을 생성 시 SSM을 통해 안전하게 값을 가져올 수 있도록 함
- 보안 강화를 위해 Resource 경로를 구체적으로 제한

## 📋 작업할 내용
- [x] SSM 읽기용 IAM 정책 정의
- [x] EC2 Role에 정책 attach
- [ ] 배포 환경에서 권한 테스트 및 확인

## 🔖 기타사항
- [ ] 추가 논의가 필요한 이슈 있음
- [ ] 외부 라이브러리 사용 예정
- [x] 보안 고려 필요

## 👀 리뷰 요구사항 (선택)
- EC2 Role에 정책이 과도하지 않은지, 최소 권한 원칙에 따라 적절한 범위인지 확인 부탁드립니다.

## 🔗 참고 자료 (선택)
- https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html
